### PR TITLE
Made the expandable content more prominent

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -21,10 +21,25 @@
 main details {
   margin-top: 1rem;
   margin-bottom: 1rem;
+  padding: 1rem 1rem 0;
+  border: 0.15rem solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-pagination-nav-border-radius);
 }
 
 main details summary {
   margin-bottom: 1rem;
+  outline: none;
+  /* Make it look like a link to notify user that it's clickable */
+  text-decoration: underline;
+}
+
+main details summary:hover {
+  cursor: pointer;
+  /* Hide the underline on hover */
+  text-decoration: none;
+}
+main details:hover {
+  border-color: var(--ifm-pagination-nav-color-hover);
 }
 
 .homePageBtns {


### PR DESCRIPTION
closes #300

## Outcome

![outcome](https://user-images.githubusercontent.com/8465237/93836622-56fa0d80-fc51-11ea-9c34-72de4ee371b7.gif)

## Changes worth mentioning

1. Added a border around the collapsible content
1. Added an underline on summary content
1. On hover
    1. Border color changes
    1. Removes underline on summary content
1. Removed existing border around `detail summary`
    ![image](https://user-images.githubusercontent.com/8465237/93836729-a80a0180-fc51-11ea-8091-ee690d7c3fbb.png)


## Additional Context

I used existing CSS variables for following control after failing to make it look consistent between dark/light themes.

![button links](https://user-images.githubusercontent.com/8465237/93836383-9e33ce80-fc50-11ea-8b65-a5b22614d64d.gif)
