### PR TITLE
Use less verbose intrinsic element props

### DIFF
--- a/docs/basic/getting-started/react-prop-type-examples.md
+++ b/docs/basic/getting-started/react-prop-type-examples.md
@@ -13,7 +13,7 @@ export declare interface AppProps {
   functionChildren: (name: string) => React.ReactNode; // recommended function as a child render prop type
   style?: React.CSSProperties; // to pass through style props
   onChange?: React.FormEventHandler<HTMLInputElement>; // form events! the generic parameter is the type of event.target
-  props: Props & React.ComponentPropsWithoutRef<"button">; // to impersonate all the props of a button element without its ref
+  props: Props & React.ComponentProps<"button">; // to impersonate all the props of a button element, then add your own. more info: https://react-typescript-cheatsheet.netlify.app/docs/advanced/patterns_by_usecase/#wrappingmirroring
 }
 ```
 

--- a/docs/basic/getting-started/react-prop-type-examples.md
+++ b/docs/basic/getting-started/react-prop-type-examples.md
@@ -13,7 +13,9 @@ export declare interface AppProps {
   functionChildren: (name: string) => React.ReactNode; // recommended function as a child render prop type
   style?: React.CSSProperties; // to pass through style props
   onChange?: React.FormEventHandler<HTMLInputElement>; // form events! the generic parameter is the type of event.target
-  props: Props & React.ComponentProps<"button">; // to impersonate all the props of a button element, then add your own. more info: https://react-typescript-cheatsheet.netlify.app/docs/advanced/patterns_by_usecase/#wrappingmirroring
+  //  more info: https://react-typescript-cheatsheet.netlify.app/docs/advanced/patterns_by_usecase/#wrappingmirroring
+  props: Props & React.ComponentPropsWithoutRef<"button">; // to impersonate all the props of a button element and explicitly not forwarding its ref
+  props2: Props & React.ComponentPropsWithRef<MyButtonWithForwardRef>; // to impersonate all the props of MyButtonForwardedRef and explicitly forwarding its ref
 }
 ```
 

--- a/docs/basic/getting-started/react-prop-type-examples.md
+++ b/docs/basic/getting-started/react-prop-type-examples.md
@@ -13,7 +13,7 @@ export declare interface AppProps {
   functionChildren: (name: string) => React.ReactNode; // recommended function as a child render prop type
   style?: React.CSSProperties; // to pass through style props
   onChange?: React.FormEventHandler<HTMLInputElement>; // form events! the generic parameter is the type of event.target
-  props: Props & React.PropsWithoutRef<JSX.IntrinsicElements["button"]>; // to impersonate all the props of a button element without its ref
+  props: Props & React.ComponentPropsWithoutRef<"button">; // to impersonate all the props of a button element without its ref
 }
 ```
 


### PR DESCRIPTION
According to https://github.com/typescript-cheatsheets/react/blob/5c22f90605654002ae31c26344a6ab2944be65c8/docs/advanced/patterns_by_usecase.md#wrappingmirroring-a-html-element, `React.ComponentProps` is a clever wrapper around `JSX.IntrinsicElements`. The former has a less verbose syntax, too.