### PR TITLE
Default props - Destructuring assignment for class component example should be inside a function

### DIFF
--- a/docs/basic/getting-started/default-props.md
+++ b/docs/basic/getting-started/default-props.md
@@ -27,8 +27,10 @@ type GreetProps =  {
 };
 
 class Greet extends React.Component<GreetProps> {
-  const { age = 21 } = this.props
-  /*...*/
+  render() {
+    const { age = 21 } = this.props;
+    /*...*/
+  }
 }
 
 let el = <Greet age={3} />;


### PR DESCRIPTION
The default props example for class components is not clear about where to use it. Since it's declaring a `const` directly inside a class and even using `this` in a place where it doesn't exist, it throws an error.

According to the issues that were used as inspiration for this change, it should be used inside functions. In this case, inside `render()` function.

Might be obvious for some people, but it took me some time to realize this is a destructuring assignment and it cannot be used as a property of the class, but as an assignment inside a function of the class.