### PR TITLE
Add format:check script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,19 +1,15 @@
 name: FormatCodeAndShowDiff
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   prettier:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          # Make sure the actual branch is checked out when running on pull requests
-          ref: ${{ github.head_ref }}
+      - uses: actions/checkout@v2
 
       - name: Get yarn cache directory
         id: yarn
@@ -28,18 +24,11 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Prettify code
-        uses: creyD/prettier_action@v2.2
-        with:
-          # This part is also where you can pass other options, for example:
-          prettier_options: --write **/*.md
+      - name: Format code
+        run: yarn format
 
-      # old formatting code
-      #- name: Format code
-      #  run: yarn format
-
-      #- name: Format correct?
-      #  run: git diff --exit-code
+      - name: Format correct?
+        run: git diff --exit-code
 
       - name: Danger for Spell Checking
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Format code
+      - name: `yarn format` changes committed?
         run: yarn format:check
 
       - name: Danger for Spell Checking

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
 name: FormatCodeAndShowDiff
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   prettier:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,10 +25,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Format code
-        run: yarn format
-
-      - name: Format correct?
-        run: git diff --exit-code
+        run: yarn format:check
 
       - name: Danger for Spell Checking
         run: |

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -87,7 +87,7 @@ see also [Things I was Wrong About: Types](https://v5.chriskrycho.com/journal/th
 
 ## Misc migration stories by notable companies and open source
 
-- [Bloomberg](https://www.techatbloomberg.com/blog/10-insights-adopting-typescript-at-scale/) 
+- [Bloomberg](https://www.techatbloomberg.com/blog/10-insights-adopting-typescript-at-scale/)
 - [Adopting TypeScript at Scale - AirBnB's conversion story and strategy](https://www.youtube.com/watch?v=P-J9Eg7hJwE)
 - [Lyft](https://eng.lyft.com/typescript-at-lyft-64f0702346ea)
 - [Google](http://neugierig.org/software/blog/2018/09/typescript-at-google.html)

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -87,7 +87,7 @@ see also [Things I was Wrong About: Types](https://v5.chriskrycho.com/journal/th
 
 ## Misc migration stories by notable companies and open source
 
-- [Bloomberg](https://www.techatbloomberg.com/blog/10-insights-adopting-typescript-at-scale/)
+- [Bloomberg](https://www.techatbloomberg.com/blog/10-insights-adopting-typescript-at-scale/) 
 - [Adopting TypeScript at Scale - AirBnB's conversion story and strategy](https://www.youtube.com/watch?v=P-J9Eg7hJwE)
 - [Lyft](https://eng.lyft.com/typescript-at-lyft-64f0702346ea)
 - [Google](http://neugierig.org/software/blog/2018/09/typescript-at-google.html)

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "format-readme": "prettier --write \"README.md\"",
     "gen-readme": "node genReadme.js",
     "format": "prettier --write \"**/*.md\"",
+    "format:check": "prettier --check \"**/*.md\"",
     "postinstall": "cd website && yarn",
     "start": "yarn --cwd website start",
     "build": "yarn --cwd website build"


### PR DESCRIPTION
This reverts commit 02f799ad77d05b22bd900e2b78c04f586a513583.

There was no reason given why we need to switch to the prettier action. However, it introduced a problematic option for actions/checkout (see https://github.com/typescript-cheatsheets/react/pull/369/checks?check_run_id=1452573120). 

We don't need to use an opaque action that is hard to use locally. The previous approach works just fine.

Proof of concept: https://github.com/typescript-cheatsheets/react/pull/370/checks?check_run_id=1452653937
