### PR TITLE
Use consistent TypeScript branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1262,7 +1262,7 @@ const AppCtx = React.createContext<AppContextInterface | null>(null);
 // Provider in your app
 
 const sampleAppContext: AppContextInterface = {
-  name: "Using React Context in a Typescript App",
+  name: "Using React Context in a TypeScript App",
   author: "thehappybug",
   url: "http://www.example.com",
 };

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -97,7 +97,7 @@ see also [Things I was Wrong About: Types](https://v5.chriskrycho.com/journal/th
 - [Priceline](https://medium.com/priceline-labs/trying-out-typescript-part-1-15a5267215b9)
 - Dropbox
   - [Talk at React Loop](https://www.youtube.com/watch?v=veXkJq0Z2Qk)
-  - [Blogpost: The Great CoffeeScript to Typescript Migration of 2017](https://dropbox.tech/frontend/the-great-coffeescript-to-typescript-migration-of-2017)
+  - [Blogpost: The Great CoffeeScript to TypeScript Migration of 2017](https://dropbox.tech/frontend/the-great-coffeescript-to-typescript-migration-of-2017)
 - [Heap - How we failed, then succeeded, at migrating to TypeScript](https://heap.io/blog/analysis/migrating-to-typescript)
 
 Open Source


### PR DESCRIPTION
> There is a capital “S” in TypeScript, just like in JavaScript.

-- https://www.typescriptlang.org/branding/