### PR TITLE
Fix inline code not showing

### DIFF
--- a/docs/advanced/patterns_by_usecase.md
+++ b/docs/advanced/patterns_by_usecase.md
@@ -459,7 +459,7 @@ Parent.propTypes = {
 
 The thing you cannot do is **specify which components** the children are, e.g. If you want to express the fact that "React Router `<Routes>` can only have `<Route>` as children, nothing else is allowed" in TypeScript.
 
-This is because when you write a JSX expression (const foo = <MyComponent foo='foo' />), the resultant type is blackboxed into a generic JSX.Element type. (_[thanks @ferdaber](https://github.com/typescript-cheatsheets/react/issues/271)_)
+This is because when you write a JSX expression (`const foo = <MyComponent foo='foo' />`), the resultant type is blackboxed into a generic JSX.Element type. (_[thanks @ferdaber](https://github.com/typescript-cheatsheets/react/issues/271)_)
 
 ## Type Narrowing based on Props
 


### PR DESCRIPTION
The component part was not being rendered, I guess markdown was trying to parse it as a Node.

<img width="656" alt="Screenshot 2020-12-02 at 13 35 56" src="https://user-images.githubusercontent.com/230893/100873272-511b7680-34a3-11eb-927c-c43c64bb3c72.png">

After this change, it will render as an inline code block