### PR TITLE
Update portals.md, due to react-hooks/exhaustive-deps

### DIFF
--- a/docs/basic/getting-started/portals.md
+++ b/docs/basic/getting-started/portals.md
@@ -43,9 +43,12 @@ const Modal: React.FC<{}> = ({ children }) => {
   const el = useRef(document.createElement("div"));
 
   useEffect(() => {
+    // Use this in case CRA throws an error about react-hooks/exhaustive-deps
+    const current = el.current;
+    
     // We assume `modalRoot` exists with '!'
-    modalRoot!.appendChild(el.current);
-    return () => void modalRoot!.removeChild(el.current);
+    modalRoot!.appendChild(current);
+    return () => void modalRoot!.removeChild(current);
   }, []);
 
   return createPortal(children, el.current);


### PR DESCRIPTION
Recently, I tried to implement your example with *hooks* above. I have bootstrapped my project with the famous create-react-app  (CRA) tool - package, but when I tried to implement the previous solution the following warning was thrown during compilation at my terminal:

```shell
src\components\__helpers__\Modal\Modal.tsx
  Line 14:50:  The ref value 'div.current' will likely have changed by the time this effect cleanup function runs. If 
  this ref points to a node rendered by React, copy 'div.current' to a variable inside the effect, and use that variable 
  in the cleanup function  react-hooks/exhaustive-deps
```

So, I followed the instructions, and assigned a different variable to `el.current`, to dismiss the warning. Now my issue is resolved, and I hope it can help other people's problems related to this unexpected warning.
