### PR TITLE
Add missing brackets in dependency array

### DIFF
--- a/docs/basic/useful-hooks.md
+++ b/docs/basic/useful-hooks.md
@@ -184,7 +184,7 @@ const task = useAsyncTask(async (data: any) => await myApiRequest(data));
 task.run(data);
 useEffect(() => {
   console.log(task.status); // 'IDLE' | 'PROCESSING' | 'ERROR' | 'SUCCESS';
-}, task.status);
+}, [task.status]);
 
 // Implementation
 


### PR DESCRIPTION
useAsyncTask (usage example):

`useEffect` hook misses brackets when specifying the dependencies.