### PR TITLE
docs: replace anchor with link to js-docs page

### DIFF
--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -15,7 +15,7 @@ Read [TypeScript's official Guide for migrating from JS](https://www.typescriptl
 ## General Conversion approaches
 
 - Level 0: Don't use TypeScript, use JSDoc
-  - See our [JSDoc section](#JSDoc)
+  - See our [JSDoc section](./js-docs.md)
 - Level 1A: Majority JavaScript, increasingly strict TypeScript
   - as recommended by [official TS guide](https://www.typescriptlang.org/docs/handbook/migrating-from-javascript.html)
   - use `allowJS` (Experiences: [clayallsop][clayallsop], [pleo][pleo])


### PR DESCRIPTION
Thanks for contributing!

- **If you are making a significant PR**, please make sure there is an open issue first
- **If you're just fixing typos or adding small notes**, a brief explanation of why you'd like to add it would be nice :)

**If you are contributing to README.md, DON'T**. README.md is auto-generated. Please just make edits to the source inside of `/docs/basic`. _Sorry, we get that it is a slight pain._
