### PR TITLE
Add return type to Function Component example

### DIFF
--- a/docs/basic/getting-started/function-components.md
+++ b/docs/basic/getting-started/function-components.md
@@ -7,6 +7,11 @@ These can be written as normal functions that take a `props` argument and return
 
 ```tsx
 type AppProps = { message: string }; /* could also use interface */
+
+// Component
+const App = ({ message }: AppProps) => <div>{message}</div>;
+
+// you can also choose to annotate the return type 
 const App = ({ message }: AppProps): JSX.Element => <div>{message}</div>;
 ```
 

--- a/docs/basic/getting-started/function-components.md
+++ b/docs/basic/getting-started/function-components.md
@@ -7,7 +7,7 @@ These can be written as normal functions that take a `props` argument and return
 
 ```tsx
 type AppProps = { message: string }; /* could also use interface */
-const App = ({ message }: AppProps) => <div>{message}</div>;
+const App = ({ message }: AppProps): JSX.Element => <div>{message}</div>;
 ```
 
 <details>


### PR DESCRIPTION
When using this example at the top of the page (https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/function_components/) in my codebase:

```tsx
type AppProps = { message: string }; /* could also use interface */
const App = ({ message }: AppProps) => <div>{message}</div>;
```

Eslint, returned this warning: 

```
Missing return type on function.eslint@typescript-eslint/explicit-module-boundary-types
```

This is due to the eslint rules that I have in place, which are extended from. a few TS and React plugins:
```
  extends: [
    'eslint:recommended',
    'plugin:react/recommended',
    'plugin:@typescript-eslint/eslint-recommended',
    'plugin:@typescript-eslint/recommended',
    'plugin:prettier/recommended',
  ],
```

To fix this issue, a return type of `JSX.Element` is needed. I think it would be useful to show that in the example because the way the docs are written, it suggests that a return type is not required.
