### PR TITLE
chore: Update danger token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,6 @@ jobs:
         run: yarn format:check
 
       - name: Danger for Spell Checking
-        run: |
-          TOKEN='dd46d414ec55efc7ce7c9a2bc84ce5ec8e5ecbb1'
-          DANGER_GITHUB_API_TOKEN=$TOKEN yarn danger ci
+        run: yarn danger ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,5 @@ jobs:
 
       - name: Danger for Spell Checking
         run: |
-          TOKEN='7469b4e94ce21b43e3ab7a'
-          TOKEN+='79960c12a1e067f2ec'
+          TOKEN='dd46d414ec55efc7ce7c9a2bc84ce5ec8e5ecbb1'
           DANGER_GITHUB_API_TOKEN=$TOKEN yarn danger ci


### PR DESCRIPTION
Part of https://github.com/typescript-cheatsheets/react/issues/395

~Created a new account. Will share credentials in an internal team discussion.~ Followed the [official docs](https://danger.systems/js/guides/getting_started.html) in which we don't need a separate token apparently.