### PR TITLE
fix minor typo

### DIFF
--- a/docs/basic/getting-started/default-props.md
+++ b/docs/basic/getting-started/default-props.md
@@ -102,7 +102,7 @@ export type ApparentGreetProps = JSX.LibraryManagedAttributes<
 >;
 ```
 
-``This will work properly, although hovering over`ApparentGreetProps`may be a little intimidating. You can reduce this boilerplate with the`ComponentProps` utility detailed below.
+This will work properly, although hovering over`ApparentGreetProps`may be a little intimidating. You can reduce this boilerplate with the`ComponentProps` utility detailed below.
 
 </details>
 


### PR DESCRIPTION
extra pair of backtick(`` ` ``) at the start of the paragraph renders the whole thing as a code block (except for the actual code terms)

<img width="594" alt="Screen Shot 2021-03-17 at 9 48 58 PM" src="https://user-images.githubusercontent.com/8132723/111501046-a20d5d00-876a-11eb-8537-0969dbef5f63.png">

---

**Note:** depends on #396 for dangerjs github token