### PR TITLE
docs: Reduce whitespace

### DIFF
--- a/docs/basic/getting-started/function-components.md
+++ b/docs/basic/getting-started/function-components.md
@@ -53,11 +53,7 @@ const Title: React.FunctionComponent<{ title: string }> = ({
 ```
 
 <details>
-<summary>
-
-Using `React.VoidFunctionComponent` or `React.VFC` instead
-
-</summary>
+<summary>Using `React.VoidFunctionComponent` or `React.VFC` instead</summary>
 
 As of [@types/react 16.9.48](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46643), you can also use `React.VoidFunctionComponent` or `React.VFC` type if you want to type `children` explicitly. This is an interim solution until `FunctionComponent` will accept no children by default (planned for `@types/react@^18.0.0`).
 


### PR DESCRIPTION
Modify a summary part inside ***Why is `React.FC` discouraged?***
- Summary icon and a title are now displayed on the same line

#### Before
<img width="989" alt="Screen Shot 2021-03-26 at 17 34 58" src="https://user-images.githubusercontent.com/52951039/112606154-64d85780-8e5b-11eb-80b3-541ad7dcb990.png">

#### After
<img width="1007" alt="Screen Shot 2021-03-26 at 17 35 03" src="https://user-images.githubusercontent.com/52951039/112606128-5ee27680-8e5b-11eb-8eb4-2cd5c97fb506.png">

