### PR TITLE
fix: Remove incorrect usage of "widening"

### DIFF
--- a/docs/basic/getting-started/forms-and-events.md
+++ b/docs/basic/getting-started/forms-and-events.md
@@ -61,7 +61,7 @@ The first method uses an inferred method signature `(e: React.FormEvent<HTMLInpu
 
 **Typing onSubmit, with Uncontrolled components in a Form**
 
-If you don't quite care about the type of the event, you can just use React.SyntheticEvent. If your target form has custom named inputs that you'd like to access, you can use type widening:
+If you don't quite care about the type of the event, you can just use React.SyntheticEvent. If your target form has custom named inputs that you'd like to access, you can use a type assertion:
 
 ```tsx
 <form


### PR DESCRIPTION
Using an intersection type in the type assertion here is actually narrowing the type, not widening it, but the intent here seems to be to introduce type assertions, not talk about the difference between wider and narrower types.

The existing text is misleading and resulted in a question in the TS Discord.