### PR TITLE
Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ function DelayedEffect(props: { timerMs: number }) {
 
 ## useRef
 
-When using `useRef`, you have two options when creating a ref container that does not have an initial value:
+When using `useRef`, you have three options when creating a ref container that does not have an initial value:
 
 ```ts
 const ref1 = useRef<HTMLElement>(null!);


### PR DESCRIPTION
The intro sentence for this section incorrectly stated that there were "two options", then the rest of the section went on to explain three options. I just changed "two" to "three" in the intro sentence .