### PR TITLE
Add rollpkg as an option for creating libraries

### DIFF
--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -14,6 +14,8 @@ title: Advanced Cheatsheet
 
 The best tool for creating React + TS libraries right now is [`tsdx`](https://github.com/palmerhq/tsdx). Run `npx tsdx create` and select the "react" option. You can view [the React User Guide](https://github.com/palmerhq/tsdx/issues/5) for a few tips on React+TS library best practices and optimizations for production.
 
+Another option is [Rollpkg](https://github.com/rafgraph/rollpkg), which uses Rollup and the TypeScript compiler (not Babel) to create packages. It includes default configs for TypeScript, Prettier, ESLint, and Jest (setup for use with React), as well as Bundlephobia package stats for each build.
+
 - Be sure to also check [`basarat`'s guide](https://basarat.gitbooks.io/typescript/content/docs/quick/library.html) for library tsconfig settings.
 - Alec Larson: [The best Rollup config for TypeScript libraries](https://gist.github.com/aleclarson/9900ed2a9a3119d865286b218e14d226)
 - From the Angular world, check out https://github.com/bitjson/typescript-starter


### PR DESCRIPTION
This adds rollpkg as another option for creating libraries with React and TypeScript.

[Rollpkg](https://github.com/rafgraph/rollpkg) uses Rollup and the TypeScript compiler to create `esm`, `cjs` and `umd` builds for both development and production, and fully supports tree shaking. It includes default configs for TypeScript, Prettier, ESLint, and Jest (setup for use with React), as well as Bundlephobia package stats for each build. Thanks!

![100155245-ebad0180-2e74-11eb-86bc-71da0ba95866](https://user-images.githubusercontent.com/11911299/115652269-f0c68d80-a2fa-11eb-854c-6b3e69e81977.gif)

