### PR TITLE
useLocalStorage Type detection bug

### DIFF
--- a/docs/basic/useful-hooks.md
+++ b/docs/basic/useful-hooks.md
@@ -37,7 +37,7 @@ function App() {
 }
 
 // Hook
-function useLocalStorage<T>(key: string, initialValue: T) {
+function useLocalStorage<T>(key: string, initialValue: T) : [T, (value: T | ((val: T) => T)) => void] {
   // State to store our value
   // Pass initial state function to useState so logic is only executed once
   const [storedValue, setStoredValue] = useState<T>(() => {


### PR DESCRIPTION
in my vs code it detects that the type of "storedValue" is (T | (value: T | ((val: T) => T)) => void)
but it must be just (T)
so it throws error 
with this change it solved.

Thanks for contributing!

- **If you are making a significant PR**, please make sure there is an open issue first
- **If you're just fixing typos or adding small notes**, a brief explanation of why you'd like to add it would be nice :)

**If you are contributing to README.md, DON'T**. README.md is auto-generated. Please just make edits to the source inside of `/docs/basic`. _Sorry, we get that it is a slight pain._
