### PR TITLE
docs: Use documented casing for compilerOptions.lib

### DIFF
--- a/docs/basic/troubleshooting/ts-config.md
+++ b/docs/basic/troubleshooting/ts-config.md
@@ -13,7 +13,7 @@ You can find [all the Compiler options in the TypeScript docs](https://www.types
     "outDir": "build/lib",
     "target": "es5",
     "module": "esnext",
-    "lib": ["dom", "esnext"],
+    "lib": ["DOM", "ESNext"],
     "sourceMap": true,
     "importHelpers": true,
     "declaration": true,


### PR DESCRIPTION
The `compilerOptions.lib` value should be upperCase , https://www.typescriptlang.org/tsconfig/#lib