### PR TITLE
[examples] update todo example year 2020 to 2021

### DIFF
--- a/docs/basic/examples.md
+++ b/docs/basic/examples.md
@@ -4,6 +4,6 @@ title: Example App
 sidebar_label: Examples
 ---
 
-- [Create React App TypeScript Todo Example 2020](https://github.com/laststance/create-react-app-typescript-todo-example-2020)
+- [Create React App TypeScript Todo Example 2021](https://github.com/laststance/create-react-app-typescript-todo-example-2021)
 - [Ben Awad's 14 hour Fullstack React/GraphQL/TypeScript Tutorial](https://www.youtube.com/watch?v=I6ypD7qv3Z8)
 - [Cypress Realworld App](https://github.com/cypress-io/cypress-realworld-app)


### PR DESCRIPTION
Hello awesome maintainers!
I'm a author of [create-react-app-typescript-todo-example](https://github.com/laststance/create-react-app-typescript-todo-example-2021) that showing example section on the cheatsheets.

Simply I've update year number and still updating this repository.
It's not a particularly important part, so I'd be happy if anyone could merge it.

Thank you!
