### PR TITLE
ForwardRef type ForwardRefRenderFunction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1787,6 +1787,8 @@ export const FancyButton = React.forwardRef<Ref, Props>((props, ref) => (
     
     Side note: the `ref` you get from `forwardRef` is mutable so you can assign to it if needed.
     
+    You may need to use React.ForwardRefRenderFunction instead of React.forwardRef
+    
   </summary>
 
 This was done [on purpose](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43265/). You can make it immutable if you have to - assign `React.Ref` if you want to ensure nobody reassigns it:


### PR DESCRIPTION
React.ForwardRefRenderFunction is needed for forward Ref

- I was just referring this for creating a forwardRef, and React said that that key does not exist.
- this is just a small note

Thanks for contributing!

- **If you are making a significant PR**, please make sure there is an open issue first
- **If you're just fixing typos or adding small notes**, a brief explanation of why you'd like to add it would be nice :)

**If you are contributing to README.md, DON'T**. README.md is auto-generated. Please just make edits to the source inside of `/docs/basic`. _Sorry, we get that it is a slight pain._
