### PR TITLE
typo: age should not be optional in defaultProps example

### DIFF
--- a/README.md
+++ b/README.md
@@ -974,7 +974,7 @@ The insight to have here is that [`GreetProps` is the _internal_ contract for yo
 ```tsx
 // internal contract, should not be exported out
 type GreetProps = {
-  age?: number;
+  age: number;
 };
 
 class Greet extends Component<GreetProps> {

--- a/README.md
+++ b/README.md
@@ -974,7 +974,7 @@ The insight to have here is that [`GreetProps` is the _internal_ contract for yo
 ```tsx
 // internal contract, should not be exported out
 type GreetProps = {
-  age: number;
+  age?: number;
 };
 
 class Greet extends Component<GreetProps> {

--- a/docs/basic/getting-started/default-props.md
+++ b/docs/basic/getting-started/default-props.md
@@ -92,7 +92,7 @@ The insight to have here is that [`GreetProps` is the _internal_ contract for yo
 ```tsx
 // internal contract, should not be exported out
 type GreetProps = {
-  age?: number;
+  age: number;
 };
 
 class Greet extends Component<GreetProps> {


### PR DESCRIPTION
Proof: https://www.typescriptlang.org/play?strict=true#code/JYWwDg9gTgLgBAJQKYEMDG8BmUIjgcilQ3wChSB6CuYAOxiSlpQBs40J6p0YAaOAM4ALCAFcWAEzi0I8AEZI4SAB6RYSKWJikYATzCKA4kSQwACjjAC4AXjgBvUnDgoA5kgBc00SAVQA3KQAvoGkaCwoAtbGSKZKygy0EtbIPAB0AMK4kLRI9AA8MaYWEFYAfA5OgjAoMMBocBJImCji5pbWdvYu7l4ATACMcCHkzkRJjAAUAJSVzvNwRDCiTHD5EsAAbmX2MELAAmlgHWluSEH5FBvbVUHB5FTxDEys7Jww3BikKmrwegZwACCYDAKHGMCK7VKnTgACkAMoADTSABlgHJuFBdABZFDMdwSQEwD7o0QMAT5Kr-JAQTBwSG8KqQkpWUhlULUoHuWxAkFgvIQkxQqwAbXwZ3wAF04I9aD4-HAAD5wUQTTB0DTkDi0ATwYFgHkzWwVRwLJYrWhrSEyiqPM7SWSLJAAR1EwCIEmCQA

`age` should be defined inside of the component, but should be rendered optional again in the exported types.  I believe this is just a typo.

Thanks for contributing!

- **If you are making a significant PR**, please make sure there is an open issue first
- **If you're just fixing typos or adding small notes**, a brief explanation of why you'd like to add it would be nice :)

**If you are contributing to README.md, DON'T**. README.md is auto-generated. Please just make edits to the source inside of `/docs/basic`. _Sorry, we get that it is a slight pain._
