### PR TITLE
Typo fix + Moved the "useFetch" example under the "<details>" tag

### DIFF
--- a/docs/basic/useful-hooks.md
+++ b/docs/basic/useful-hooks.md
@@ -237,7 +237,12 @@ See also: [useAsync](https://usehooks.com/useAsync/).
 
 ## useFetch
 
-This Hook is usefull to make fetch request using `AbortController`
+This Hook is useful to make fetch requests using `AbortController`
+
+<details>
+<summary>
+Example implementation
+</summary>
 
 ```tsx
 export function useFetch(request: RequestInfo, init?: RequestInit) {
@@ -272,3 +277,5 @@ export function useFetch(request: RequestInfo, init?: RequestInit) {
   return { response, error, isLoading };
 }
 ```
+
+</details>


### PR DESCRIPTION
While going through docs I found a typo or grammatical mistakes like
1. 'usefull' instead of 'useful'
2. fetch request instead of 'a fetch request' or 'fetch requests'

I even found the inconsistency in the `useful-hook.md` file i.e. all the examples were under `<details>` tag except the `useFetch` section example, hence I moved the example under the `<details>` tag
