### PR TITLE
Fix formatting on useEffect hook

### DIFF
--- a/docs/basic/getting-started/hooks.md
+++ b/docs/basic/getting-started/hooks.md
@@ -101,8 +101,7 @@ Both of `useEffect` and `useLayoutEffect` are used for performing <b>side effect
 function DelayedEffect(props: { timerMs: number }) {
   const { timerMs } = props;
 
-  useEffect(
-    () =>
+  useEffect(() =>
       setTimeout(() => {
         /* do stuff */
       }, timerMs),


### PR DESCRIPTION
Moves the callback function in the bad example to the same place in the good example to make it easier to see exactly why they're different