### PR TITLE
added intellij dependencies to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,7 @@ docs/contributing.md
 # Lock-files
 package-lock.json
 yarn.lock
+
+#intellij
+.idea
+*.iml


### PR DESCRIPTION
adding intellij dependencies to gitignore so that the iml files and such don't accidentally get pushed if someone chooses to use intellij ide
