### PR TITLE
fix: docs/basic/troubleshooting/types.md spelling mistake

### DIFF
--- a/docs/basic/troubleshooting/types.md
+++ b/docs/basic/troubleshooting/types.md
@@ -350,9 +350,9 @@ function foo() {
 
 type InstType = ReturnType<typeof foo>;
 type SubInstArr = InstType["subInstArr"];
-type SubIsntType = SubInstArr[0];
+type SubInstType = SubInstArr[0];
 
-let baz: SubIsntType = {
+let baz: SubInstType = {
   c: 5,
   d: 6, // type checks ok!
 };
@@ -360,8 +360,8 @@ let baz: SubIsntType = {
 //You could just write a one-liner,
 //But please make sure it is forward-readable
 //(you can understand it from reading once left-to-right with no jumps)
-type SubIsntType2 = ReturnType<typeof foo>["subInstArr"][0];
-let baz2: SubIsntType2 = {
+type SubInstType2 = ReturnType<typeof foo>["subInstArr"][0];
+let baz2: SubInstType2 = {
   c: 5,
   d: 6, // type checks ok!
 };


### PR DESCRIPTION
rename `SubIsntType` to `SubInstType`, because the **inst** is a single world, not **isnt**.

<!--
Thanks for contributing!

- **If you are making a significant PR**, please make sure there is an open issue first
- **If you're just fixing typos or adding small notes**, a brief explanation of why you'd like to add it would be nice :)

**If you are contributing to README.md, DON'T**. README.md is auto-generated. Please just make edits to the source inside of `/docs/basic`. _Sorry, we get that it is a slight pain._
-->