### PR TITLE
docs: add an article about `defaultProps`

### DIFF
--- a/docs/basic/getting-started/default-props.md
+++ b/docs/basic/getting-started/default-props.md
@@ -5,9 +5,10 @@ title: Typing defaultProps
 
 ## You May Not Need `defaultProps`
 
-As per [this tweet](https://twitter.com/dan_abramov/status/1133878326358171650), defaultProps will eventually be deprecated. You can check the discussions here:
+As per [this tweet](https://twitter.com/dan_abramov/status/1133878326358171650) defaultProps will eventually be deprecated. You can check the discussions here:
 
-- https://twitter.com/hswolff/status/1133759319571345408
+- [Original tweet](https://twitter.com/hswolff/status/1133759319571345408)
+- More info can also be found in [this article](https://medium.com/@matanbobi/react-defaultprops-is-dying-whos-the-contender-443c19d9e7f1)
 
 The consensus is to use object default values.
 

--- a/docs/basic/getting-started/default-props.md
+++ b/docs/basic/getting-started/default-props.md
@@ -5,7 +5,7 @@ title: Typing defaultProps
 
 ## You May Not Need `defaultProps`
 
-As per [this tweet](https://twitter.com/dan_abramov/status/1133878326358171650) defaultProps will eventually be deprecated. You can check the discussions here:
+As per [this tweet](https://twitter.com/dan_abramov/status/1133878326358171650), defaultProps will eventually be deprecated. You can check the discussions here:
 
 - [Original tweet](https://twitter.com/hswolff/status/1133759319571345408)
 - More info can also be found in [this article](https://medium.com/@matanbobi/react-defaultprops-is-dying-whos-the-contender-443c19d9e7f1)


### PR DESCRIPTION
Hi!
I saw that the page for not using `defaultProps` only contains a link to a tweet by Dan saying `defaultProps` will eventually be deprecated but that's not the only reason people should stop using them.
I actually wrote a post back then on July 2019 about the performance implications of `defaultProps`.
I think it's worth adding that here, but feel free to also dismiss it if you don't see it's value.

Thanks!