### PR TITLE
Recommend `@ts-expect-error` over `@ts-ignore`

### DIFF
--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -28,7 +28,7 @@ Read [TypeScript's official Guide for migrating from JS](https://www.typescriptl
 
 Misc tips/approaches successful companies have taken
 
-- `@ts-ignore` on compiler errors for libraries with no typedefs
+- `@ts-expect-error` on compiler errors for libraries with no typedefs
 - pick ESLint over TSLint (source: [ESLint](https://eslint.org/blog/2019/01/future-typescript-eslint) and [TS Roadmap](https://github.com/Microsoft/TypeScript/issues/29288)). [You can convert TSlint to ESlint with this tool](https://github.com/typescript-eslint/tslint-to-eslint-config).
 - New code must always be written in TypeScript. No exceptions. For existing code: If your task requires you to change JavaScript code, you need to rewrite it. (Source: [Hootsuite][hootsuite])
 


### PR DESCRIPTION
it's better to use expect error rather than `ts-ignore` as it will show up as an error if the type get's fixed

Thanks for contributing!

- **If you are making a significant PR**, please make sure there is an open issue first
- **If you're just fixing typos or adding small notes**, a brief explanation of why you'd like to add it would be nice :)

**If you are contributing to README.md, DON'T**. README.md is auto-generated. Please just make edits to the source inside of `/docs/basic`. _Sorry, we get that it is a slight pain._
