### PR TITLE
chore: remove deprecated chinese translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
 <p>Cheatsheets for experienced React developers getting started with TypeScript</p>
 
 [**Web docs**](https://react-typescript-cheatsheet.netlify.app/docs/basic/setup) |
-[中文翻译](https://github.com/fi3ework/blog/tree/master/react-typescript-cheatsheet-cn) |
 [**Español**](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet-es) |
 [**Português**](https://github.com/typescript-cheatsheets/react-pt) |
 [Contribute!](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet/blob/master/CONTRIBUTING.md) |


### PR DESCRIPTION
The Chinese translation was deprecated a few years ago and doesn't really contain anything: https://github.com/fi3ework/blog/commit/3e5d02ca6099c10b7f690edf9157cfbd711209d3