### PR TITLE
remove react.fc from examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1858,12 +1858,16 @@ export class Modal extends React.Component<{ children?: React.ReactNode }> {
 Same as above but using hooks
 
 ```tsx
-import React, { useEffect, useRef } from "react";
+import { useEffect, useRef, ReactNode } from "react";
 import { createPortal } from "react-dom";
 
 const modalRoot = document.querySelector("#modal-root") as HTMLElement;
 
-const Modal: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+interface ModalProps {
+  children?: ReactNode;
+}
+
+const Modal = ({ children }: ModalProps) => {
   const el = useRef(document.createElement("div"));
 
   useEffect(() => {
@@ -2206,8 +2210,8 @@ type DogProps = {
 type HumanProps = {
   handsCount: number
 }
-export const Human: React.FC<BaseProps & HumanProps> = // ...
-export const Dog: React.FC<BaseProps & DogProps> = // ...
+export const Human = (props: BaseProps & HumanProps) => // ...
+export const Dog = (props: BaseProps & DogProps) => // ...
 ```
 
 [View in the TypeScript Playground](https://www.typescriptlang.org/play/?jsx=2#code/JYWwDg9gTgLgBAJQKYEMDG8BmUIjgcilQ3wFgAoCmATzCTgCEUBnJABRzGbgF44BvCnGFoANi2YA5FCCQB+AFxxmMKMAB2AcwA0Q4Suqj5S5OhgA6AMIBlaxwh1YwJMz1x1MpEpVqtcAPT+cACurAAmcBpwAEYQMAAWFAC+VLT0ACIQmvZcvAJ6MCjAosyWEMHqMErqwSDRSFDJqXRwABK1KOo53HyC5MLxnWGl5ZXVtfWN5CnkSAAekLBwaBDqKm0d6ibEFgBilgA8TKzdcABkGyCd3QB8eQAUAJS8d-d6B2HAAG4BNxSPFAo80W8BWa3gmU02zM5n2RxY7E43AukNuD2ePFe70+P38f3IjyAA)
@@ -2309,7 +2313,7 @@ This can be annoying but here are ways to grab the types!
 import { Button } from "library"; // but doesn't export ButtonProps! oh no!
 type ButtonProps = React.ComponentProps<typeof Button>; // no problem! grab your own!
 type AlertButtonProps = Omit<ButtonProps, "onClick">; // modify
-const AlertButton: React.FC<AlertButtonProps> = (props) => (
+const AlertButton = (props: AlertButtonProps) => (
   <Button onClick={() => alert("hello")} {...props} />
 );
 ```

--- a/docs/advanced/patterns_by_usecase.md
+++ b/docs/advanced/patterns_by_usecase.md
@@ -678,7 +678,7 @@ function MyComponent(props: Props1 | Props2) {
     return <div>{props.bar}</div>;
   }
 }
-const UsageComponent: React.FC = () => (
+const UsageComponent = () => (
   <div>
     <MyComponent foo="foo" />
     <MyComponent bar="bar" />
@@ -716,7 +716,7 @@ You want to allow `expanded` to be passed only if `truncate` is also passed, bec
 Usage example:
 
 ```tsx
-const App: React.FC = () => (
+const App = () => (
   <>
     {/* these all typecheck */}
     <Text>not truncated</Text>

--- a/docs/basic/getting-started/portals.md
+++ b/docs/basic/getting-started/portals.md
@@ -34,12 +34,16 @@ export class Modal extends React.Component<{ children?: React.ReactNode }> {
 Same as above but using hooks
 
 ```tsx
-import React, { useEffect, useRef } from "react";
+import { useEffect, useRef, ReactNode } from "react";
 import { createPortal } from "react-dom";
 
 const modalRoot = document.querySelector("#modal-root") as HTMLElement;
 
-const Modal: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+interface ModalProps {
+  children?: ReactNode;
+}
+
+const Modal = ({ children }: ModalProps) => {
   const el = useRef(document.createElement("div"));
 
   useEffect(() => {

--- a/docs/basic/troubleshooting/types.md
+++ b/docs/basic/troubleshooting/types.md
@@ -208,8 +208,8 @@ type DogProps = {
 type HumanProps = {
   handsCount: number
 }
-export const Human: React.FC<BaseProps & HumanProps> = // ...
-export const Dog: React.FC<BaseProps & DogProps> = // ...
+export const Human = (props: BaseProps & HumanProps) => // ...
+export const Dog = (props: BaseProps & DogProps) => // ...
 ```
 
 [View in the TypeScript Playground](https://www.typescriptlang.org/play/?jsx=2#code/JYWwDg9gTgLgBAJQKYEMDG8BmUIjgcilQ3wFgAoCmATzCTgCEUBnJABRzGbgF44BvCnGFoANi2YA5FCCQB+AFxxmMKMAB2AcwA0Q4Suqj5S5OhgA6AMIBlaxwh1YwJMz1x1MpEpVqtcAPT+cACurAAmcBpwAEYQMAAWFAC+VLT0ACIQmvZcvAJ6MCjAosyWEMHqMErqwSDRSFDJqXRwABK1KOo53HyC5MLxnWGl5ZXVtfWN5CnkSAAekLBwaBDqKm0d6ibEFgBilgA8TKzdcABkGyCd3QB8eQAUAJS8d-d6B2HAAG4BNxSPFAo80W8BWa3gmU02zM5n2RxY7E43AukNuD2ePFe70+P38f3IjyAA)
@@ -311,7 +311,7 @@ This can be annoying but here are ways to grab the types!
 import { Button } from "library"; // but doesn't export ButtonProps! oh no!
 type ButtonProps = React.ComponentProps<typeof Button>; // no problem! grab your own!
 type AlertButtonProps = Omit<ButtonProps, "onClick">; // modify
-const AlertButton: React.FC<AlertButtonProps> = (props) => (
+const AlertButton = (props: AlertButtonProps) => (
   <Button onClick={() => alert("hello")} {...props} />
 );
 ```


### PR DESCRIPTION
We're saying that using `React.FC` for typing functional components is discouraged here: https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/function_components

Still, we're using it in a few example. I'd prefer not using it at all, but open for discussion.