### PR TITLE
docs(hooks): improving useImperativeHandle example

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,21 +559,52 @@ function Foo() {
 
 #### useImperativeHandle
 
-_We don't have much here, but this is from [a discussion in our issues](https://github.com/typescript-cheatsheets/react/issues/106). Please contribute if you have anything to add!_
+Based on this [Stackoverflow answer](https://stackoverflow.com/a/69292925/5415299):
 
 ```tsx
-type ListProps<ItemType> = {
-  items: ItemType[];
-  innerRef?: React.Ref<{ scrollToItem(item: ItemType): void }>;
+// Countdown.tsx
+
+// Define the handle types which will be passed to the forwardRef
+export type CountdownHandle = {
+  start: () => void;
 };
 
-function List<ItemType>(props: ListProps<ItemType>) {
-  useImperativeHandle(props.innerRef, () => ({
-    scrollToItem() {},
+type CountdownProps = {};
+
+const Countdown = forwardRef<CountdownHandle, CountdownProps>((props, ref) => {
+  useImperativeHandle(ref, () => ({
+    // start() has type inference here
+    start() {
+      alert("Start");
+    },
   }));
-  return null;
+
+  return <div>Countdown</div>;
+});
+```
+
+```tsx
+// The component uses the Countdown component
+
+import Countdown, { CountdownHandle } from "./Countdown.tsx";
+
+function App() {
+  const countdownEl = useRef<CountdownHandle>(null);
+
+  useEffect(() => {
+    if (countdownEl.current) {
+      // start() has type inference here as well
+      countdownEl.current.start();
+    }
+  }, []);
+
+  return <Countdown ref={countdownEl} />;
 }
 ```
+
+##### See also:
+
+- [Using ForwardRefRenderFunction](https://stackoverflow.com/a/62258685/5415299)
 
 #### Custom Hooks
 

--- a/docs/basic/getting-started/hooks.md
+++ b/docs/basic/getting-started/hooks.md
@@ -244,7 +244,7 @@ function App() {
 
   useEffect(() => {
     if (countdownEl.current) {
-      // start() has type inferrence here as well
+      // start() has type inference here as well
       countdownEl.current.start();
     }
   }, []);

--- a/docs/basic/getting-started/hooks.md
+++ b/docs/basic/getting-started/hooks.md
@@ -210,21 +210,52 @@ function Foo() {
 
 ## useImperativeHandle
 
-_We don't have much here, but this is from [a discussion in our issues](https://github.com/typescript-cheatsheets/react/issues/106). Please contribute if you have anything to add!_
+Based on this [Stackoverflow answer](https://stackoverflow.com/a/69292925/5415299):
 
 ```tsx
-type ListProps<ItemType> = {
-  items: ItemType[];
-  innerRef?: React.Ref<{ scrollToItem(item: ItemType): void }>;
+// Countdown.tsx
+
+// Define the handle types which will be passed to the forwardRef
+export type CountdownHandle = {
+  start: () => void;
 };
 
-function List<ItemType>(props: ListProps<ItemType>) {
-  useImperativeHandle(props.innerRef, () => ({
-    scrollToItem() {},
+type CountdownProps = {};
+
+const Countdown = forwardRef<CountdownHandle, CountdownProps>((props, ref) => {
+  useImperativeHandle(ref, () => ({
+    // start() has type inference here
+    start() {
+      alert('Start');
+    },
   }));
-  return null;
+
+  return <div>Countdown</div>;
+});
+```
+  
+```tsx  
+// The component uses the Countdown component
+
+import Countdown, { CountdownHandle } from "./Countdown.tsx";
+
+function App() {
+  const countdownEl = useRef<CountdownHandle>(null);
+
+  useEffect(() => {
+    if (countdownEl.current) {
+      // start() has type inferrence here as well
+      countdownEl.current.start();
+    }
+  }, []);
+
+  return <Countdown ref={countdownEl} />;
 }
 ```
+  
+### See also:
+  
+- [Using ForwardRefRenderFunction](https://stackoverflow.com/a/62258685/5415299)
 
 ## Custom Hooks
 

--- a/docs/basic/getting-started/hooks.md
+++ b/docs/basic/getting-started/hooks.md
@@ -226,15 +226,15 @@ const Countdown = forwardRef<CountdownHandle, CountdownProps>((props, ref) => {
   useImperativeHandle(ref, () => ({
     // start() has type inference here
     start() {
-      alert('Start');
+      alert("Start");
     },
   }));
 
   return <div>Countdown</div>;
 });
 ```
-  
-```tsx  
+
+```tsx
 // The component uses the Countdown component
 
 import Countdown, { CountdownHandle } from "./Countdown.tsx";
@@ -252,9 +252,9 @@ function App() {
   return <Countdown ref={countdownEl} />;
 }
 ```
-  
+
 ### See also:
-  
+
 - [Using ForwardRefRenderFunction](https://stackoverflow.com/a/62258685/5415299)
 
 ## Custom Hooks


### PR DESCRIPTION
Just stumbled upon the current explanation for the [useImperativeHandle](https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/hooks/#useimperativehandle) and saw that it is pretty basic.

I found a better way to type useImperativeHandle on [this Stackoverflow answer](https://stackoverflow.com/questions/62210286/declare-type-with-react-useimperativehandle) and thought we can use this one instead, which is more complete.