### PR TITLE
Move contributing pages from docs to pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,8 +126,8 @@ website/.docusaurus
 website/.cache-loader
 
 # copy of contributors for the website
-docs/contributors.md
-docs/contributing.md
+website/src/pages/contributing.md
+website/src/pages/contributors.md
 
 # Local Netlify folder
 .netlify

--- a/copyFile.js
+++ b/copyFile.js
@@ -2,34 +2,13 @@ const fs = require("fs");
 const filesTopCopy = [
   {
     src: "../CONTRIBUTORS.md",
-    dest: "../docs/contributors.md",
-    hideHeader: true,
+    dest: "src/pages/contributors.md",
   },
   {
     src: "../CONTRIBUTING.md",
-    dest: "../docs/contributing.md",
-    hideHeader: true,
+    dest: "src/pages/contributing.md",
   },
 ];
-
-const generatingPageOptions = `---
-hide_title: true
----
-
-`;
-
-function writeNewFile(src, dest) {
-  const fileContent = fs.readFileSync(src).toString();
-  const data = new Uint8Array(Buffer.from(generatingPageOptions + fileContent));
-
-  fs.writeFile(dest, data, (err) => {
-    if (err) {
-      console.log("Error Found:", err);
-    } else {
-      console.log("Files added");
-    }
-  });
-}
 
 function copyFile(src, dest) {
   fs.copyFile(src, dest, (err) => {
@@ -41,10 +20,6 @@ function copyFile(src, dest) {
   });
 }
 
-filesTopCopy.forEach(({ src, dest, hideHeader }) => {
-  if (hideHeader) {
-    writeNewFile(src, dest);
-  } else {
-    copyFile(src, dest);
-  }
+filesTopCopy.forEach(({ src, dest }) => {
+  copyFile(src, dest);
 });

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -9,8 +9,6 @@ const users = [
 ];
 
 const setupDoc = "docs/basic/setup";
-const contributorsDoc = "docs/contributors";
-const contributingDoc = "docs/contributing";
 
 module.exports = {
   favicon: "img/icon.png",
@@ -79,11 +77,6 @@ module.exports = {
           label: "Discord",
           position: "right",
         },
-        {
-          to: contributorsDoc,
-          label: "Contributors",
-          position: "right",
-        },
         // {to: 'blog', label: 'Blog', position: 'right'},
       ],
     },
@@ -117,10 +110,6 @@ module.exports = {
               label: "Migrating",
               to: "docs/migration",
             },
-            {
-              label: "Contributing",
-              to: contributingDoc,
-            },
           ],
         },
         {
@@ -140,7 +129,11 @@ module.exports = {
             },
             {
               label: "Contributors",
-              to: contributorsDoc,
+              to: "contributors",
+            },
+            {
+              label: "Contributing",
+              to: "contributing",
             },
           ],
         },


### PR DESCRIPTION
Since https://react-typescript-cheatsheet.netlify.app/docs/contributing and https://react-typescript-cheatsheet.netlify.app/docs/contributors are copied from CONTRIBUTING.md and CONTRIBUTORS.md when deploying, they are no regular doc pages, and the edit page link won't work.

One solution could be to configure the edit URL for these pages to the source markdown files. But I think we should treat these as pages rather than docs, which will remove the edit page link instead.

Let's keep the links to these pages in the community section of the footer, but remove the link to the contributors page from the header. That page is outdated and not part of the most important links of the site.