### PR TITLE
fix: help page links spacing 

### DIFF
--- a/website/src/pages/help.js
+++ b/website/src/pages/help.js
@@ -47,9 +47,9 @@ export default function Help() {
           <p>This project is maintained by a dedicated group of people.</p>
         </div>
 
-        <div className="row margin-vert--xl">
+        <div className="row">
           {supportLinks.map((supportLink, i) => (
-            <div className="col col--4" key={i}>
+            <div className="col col--4 margin-top--lg" key={i}>
               <SupportLink {...supportLink} />
             </div>
           ))}


### PR DESCRIPTION
The spacing for the help page links was a little messed up on mobile.

These edits fix the issue.

<img width="512" alt="Screenshot 2022-10-30 at 11 33 27 AM" src="https://user-images.githubusercontent.com/47117192/198890258-5f0a0b3d-8933-4f7b-abc4-ba6095ad6d01.png">
