### PR TITLE
Removing dead link in migration from flow page

### DIFF
--- a/docs/migration/from-flow.md
+++ b/docs/migration/from-flow.md
@@ -8,7 +8,6 @@ title: From Flow
 - Try [Airtable's codemod](https://github.com/Airtable/typescript-migration-codemod): https://medium.com/airtable-eng/the-continual-evolution-of-airtables-codebase-migrating-a-million-lines-of-code-to-typescript-612c008baf5c
 - [Incremental Migration to TypeScript on a Flowtype codebase][entria] at Entria
 - [MemSQL's Studio's migration](https://davidgom.es/porting-30k-lines-of-code-from-flow-to-typescript/) - blogpost with many useful tips
-- Retail-UI's Codemod: https://github.com/skbkontur/retail-ui/tree/master/packages/react-ui-codemodes/flow-to-ts
 - Quick-n-dirty [Flow to TS Codemod](https://gist.github.com/skovhus/c57367ce6ecbc3f70bb7c80f25727a11)
 - [Ecobee's brief experience](https://mobile.twitter.com/alanhietala/status/1104450494754377728)
 - [Migrating a 50K SLOC Flow + React Native app to TypeScript](https://blog.usejournal.com/migrating-a-flow-react-native-app-to-typescript-c74c7bceae7d)


### PR DESCRIPTION
Retail-UI's Codemod page doesn't exist anymore, I'm removing its reference in migration from flow page.
