### PR TITLE
Navbar "S" missing in Cheatsheets

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -56,7 +56,7 @@ module.exports = {
     },
 
     navbar: {
-      title: "React TypeScript Cheatsheet",
+      title: "React TypeScript Cheatsheets",
       logo: {
         alt: "Logo",
         src: "img/icon.png",

--- a/website/src/pages/help.js
+++ b/website/src/pages/help.js
@@ -47,9 +47,9 @@ export default function Help() {
           <p>This project is maintained by a dedicated group of people.</p>
         </div>
 
-        <div className="row margin-vert--xl">
+        <div className="row">
           {supportLinks.map((supportLink, i) => (
-            <div className="col col--4" key={i}>
+            <div className="col col--4 margin-top--lg" key={i}>
               <SupportLink {...supportLink} />
             </div>
           ))}


### PR DESCRIPTION
was just checking your website again and found that the navbar has 'React TypeScript Cheatsheet' instead of 'React TypeScript Cheatsheets'. I fixed it