### PR TITLE
Remove readonly keyword from the state

### DIFF
--- a/docs/basic/getting-started/context.md
+++ b/docs/basic/getting-started/context.md
@@ -267,7 +267,7 @@ class Provider extends React.Component<
   { children?: ReactNode },
   ProviderState
 > {
-  public readonly state = {
+  public state = {
     themeColor: "red",
   };
 


### PR DESCRIPTION
Based on this [PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/26813) we don't have to put `readonly` for our states, because `React.Component<P,S>` already marks them as immutable.
