### PR TITLE
Added link of React and TypeScript Roadmap

### DIFF
--- a/docs/basic/recommended/resources.md
+++ b/docs/basic/recommended/resources.md
@@ -33,3 +33,5 @@ sidebar_label: Other resources
   - [Microsoft React TypeScript conversion guide](https://github.com/Microsoft/TypeScript-React-Conversion-Guide#typescript-react-conversion-guide)
 - [Matt Pocock's Beginner's Typescript Tutorial](https://github.com/total-typescript/beginners-typescript-tutorial)
 - [You?](https://github.com/typescript-cheatsheets/react/issues/new).
+- [React Roadmap](https://roadmap.sh/react).
+- [TypeScript Roadmap](https://roadmap.sh/typescript).


### PR DESCRIPTION
Hi @maafaishal,

I came across your repository [react](https://github.com/typescript-cheatsheets/react) and found it to be a valuable resource for React and TypeScript enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["React Developer Roadmap"](https://roadmap.sh/react) and ["TypeScript Developer Roadmap"](https://roadmap.sh/typescript). I took the initiative to submit a ["Pull Request"](https://github.com/typescript-cheatsheets/react/pull/611) adding it in "/docs/basic)/recommended/ > resources".

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz