### PR TITLE
Add ComponentProps reference as first React Types example

### DIFF
--- a/docs/react-types/ComponentProps.md
+++ b/docs/react-types/ComponentProps.md
@@ -1,12 +1,12 @@
 ---
-title: ComponentProps<T>
+title: ComponentProps<Element>
 ---
 
-`ComponentProps<T>` is a utility type that lets you grab all valid props of an element, or infer prop type of a component.
+`ComponentProps<Element>` is a utility type that lets you grab all valid props of an element, or infer prop type of a component.
 
 :::note
 
-Prefer `ComponentPropsWithRef<T>` if ref is forwarded and `ComponentPropsWithoutRef<T>` when ref is not forwarded.
+Prefer `ComponentPropsWithRef<Element>` if ref is forwarded and `ComponentPropsWithoutRef<Element>` when ref is not forwarded.
 
 :::
 
@@ -20,7 +20,7 @@ Prefer `ComponentPropsWithRef<T>` if ref is forwarded and `ComponentPropsWithout
 
 ### Getting all valid props of an element
 
-`ComponentProps<T>` can be used to create a type that includes all valid `div` props.
+`ComponentProps<Element>` can be used to create a type that includes all valid `div` props.
 
 ```tsx
 interface Props extends ComponentProps<"div"> {
@@ -63,5 +63,14 @@ However, this type if not really reflecting the actual set of icons made availab
 import { Icon } from "component-library";
 
 type IconName = ComponentProps<typeof Icon>["name"];
-//       ^? type IconName = "warning" | "checkmark" | ...
+//       ^? type IconName = "warning" | "checkmark"
+```
+
+You can also use the `Pick<Type, Keys>` utility type to accomplish the same thing:
+
+```tsx
+import { Icon } from "component-library";
+
+type IconName = Pick<ComponentProps<typeof Icon>, "name">;
+//       ^? type IconName = "warning" | "checkmark"
 ```

--- a/docs/react-types/ComponentProps.md
+++ b/docs/react-types/ComponentProps.md
@@ -1,26 +1,26 @@
 ---
-title: ComponentProps<Element>
+title: ComponentProps<ElementType>
 ---
 
-`ComponentProps<Element>` is a utility type that lets you grab all valid props of an element, or infer prop type of a component.
+`ComponentProps<ElementType>` constructs a type with all valid props of an element or inferred props of a component.
 
 :::note
 
-Prefer `ComponentPropsWithRef<Element>` if ref is forwarded and `ComponentPropsWithoutRef<Element>` when ref is not forwarded.
+Prefer `ComponentPropsWithRef<ElementType>` if ref is forwarded and `ComponentPropsWithoutRef<ElementType>` when ref is not forwarded.
 
 :::
 
 ## Parameters
 
-- `T`: An element type. Examples include:
-  - An HTML or SVG element such as `"div"`, `"h1"` or `"path"`.
+- `ElementType`: An element type. Examples include:
+  - An HTML or SVG element string literal such as `"div"`, `"h1"` or `"path"`.
   - A component type, such as `typeof Component`.
 
 ## Usage
 
-### Getting all valid props of an element
+### Get all valid props of an element
 
-`ComponentProps<Element>` can be used to create a type that includes all valid `div` props.
+`ComponentProps<ElementType>` can be used to create a type that includes all valid `div` props.
 
 ```tsx
 interface Props extends ComponentProps<"div"> {
@@ -28,11 +28,11 @@ interface Props extends ComponentProps<"div"> {
 }
 
 function Component({ className, children, text, ...props }: Props) {
-  // `Props` includes `text` in addition to all valid `div` props
+  // `props` includes `text` in addition to all valid `div` props
 }
 ```
 
-### Infer prop types from a component
+### Infer component props type
 
 In some cases, you might want to infer the type of a component's props.
 
@@ -49,7 +49,7 @@ type MyType = ComponentProps<typeof Component>;
 //     ^? type MyType = Props
 ```
 
-#### Inferring specific prop type
+#### Infer specific prop type
 
 The type of a specific prop can also be inferred this way. Let's say you are using an `<Icon>` component from a component library. The component takes a `name` prop that determines what icon is shown. You need to use the type of `name` in your app, but it's not made available by the library. You could create a custom type:
 

--- a/docs/react-types/ComponentProps.md
+++ b/docs/react-types/ComponentProps.md
@@ -2,19 +2,23 @@
 title: ComponentProps<T>
 ---
 
-`ComponentProps<T>` is a utility type that lets you grab all valid props of an HTML or SVG element, or infer prop type for a component.
+`ComponentProps<T>` is a utility type that lets you grab all valid props of an element, or infer prop type of a component.
+
+:::note
+
+Prefer `ComponentPropsWithRef<T>` if ref is forwarded and `ComponentPropsWithoutRef<T>` when ref is not forwarded.
+
+:::
 
 ## Parameters
 
-- `T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>`
-
-`keyof JSX.IntrinsicElements` is a set of all HTML and SVG elements, such as `"div"`, `"h1"` and `"path"`.
-
-`JSXElementConstructor<any>` is the type of a function or class component.
+- `T`: An element type. Examples include:
+  - An HTML or SVG element such as `"div"`, `"h1"` or `"path"`.
+  - A component type, such as `typeof Component`.
 
 ## Usage
 
-### Getting all valid props of an HTML or SVG element
+### Getting all valid props of an element
 
 `ComponentProps<T>` can be used to create a type that includes all valid `div` props.
 
@@ -23,8 +27,8 @@ interface Props extends ComponentProps<"div"> {
   text: string;
 }
 
-function Component({ className, children, text }: Props) {
-  // ...
+function Component({ className, children, text, ...props }: Props) {
+  // `Props` includes `text` in addition to all valid `div` props
 }
 ```
 
@@ -45,7 +49,15 @@ type MyType = ComponentProps<typeof Component>;
 //     ^? type MyType = Props
 ```
 
-The type of a specific prop can also be inferred this way. Let's say you are using an `<Icon>` component from a component library. The component takes a `name` prop that determines what icon is shown. You need to use the type of `name` in your app, but it's not made available by the library. No problem!
+#### Inferring specific prop type
+
+The type of a specific prop can also be inferred this way. Let's say you are using an `<Icon>` component from a component library. The component takes a `name` prop that determines what icon is shown. You need to use the type of `name` in your app, but it's not made available by the library. You could create a custom type:
+
+```tsx
+type IconName = "warning" | "checkmark";
+```
+
+However, this type if not really reflecting the actual set of icons made available by the library. A better solution is to infer the type:
 
 ```tsx
 import { Icon } from "component-library";
@@ -53,5 +65,3 @@ import { Icon } from "component-library";
 type IconName = ComponentProps<typeof Icon>["name"];
 //       ^? type IconName = "warning" | "checkmark" | ...
 ```
-
-Needless to say, `ComponentProps<T>` can be very useful!

--- a/docs/react-types/ComponentProps.md
+++ b/docs/react-types/ComponentProps.md
@@ -1,0 +1,57 @@
+---
+title: ComponentProps<T>
+---
+
+`ComponentProps<T>` is a utility type that lets you grab all valid props of an HTML or SVG element, or infer prop type for a component.
+
+## Parameters
+
+- `T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>`
+
+`keyof JSX.IntrinsicElements` is a set of all HTML and SVG elements, such as `"div"`, `"h1"` and `"path"`.
+
+`JSXElementConstructor<any>` is the type of a function or class component.
+
+## Usage
+
+### Getting all valid props of an HTML or SVG element
+
+`ComponentProps<T>` can be used to create a type that includes all valid `div` props.
+
+```tsx
+interface Props extends ComponentProps<"div"> {
+  text: string;
+}
+
+function Component({ className, children, text }: Props) {
+  // ...
+}
+```
+
+### Infer prop types from a component
+
+In some cases, you might want to infer the type of a component's props.
+
+```tsx
+interface Props {
+  text: string;
+}
+
+function Component(props: Props) {
+  // ...
+}
+
+type MyType = ComponentProps<typeof Component>;
+//     ^? type MyType = Props
+```
+
+The type of a specific prop can also be inferred this way. Let's say you are using an `<Icon>` component from a component library. The component takes a `name` prop that determines what icon is shown. You need to use the type of `name` in your app, but it's not made available by the library. No problem!
+
+```tsx
+import { Icon } from "component-library";
+
+type IconName = ComponentProps<typeof Icon>["name"];
+//       ^? type IconName = "warning" | "checkmark" | ...
+```
+
+Needless to say, `ComponentProps<T>` can be very useful!

--- a/docs/react-types/index.md
+++ b/docs/react-types/index.md
@@ -1,0 +1,7 @@
+---
+title: React Types
+---
+
+`@types/react` makes some types available that can be very useful. Here's a list in alphabetical order with links to the detailed reference pages.
+
+- [`ComponentProps<T>`](/docs/react-types/ComponentProps)

--- a/docs/react-types/index.md
+++ b/docs/react-types/index.md
@@ -4,4 +4,4 @@ title: React Types
 
 `@types/react` makes some types available that can be very useful. Here's a list in alphabetical order with links to the detailed reference pages.
 
-- [`ComponentProps<T>`](/docs/react-types/ComponentProps)
+- [`ComponentProps<ElementType>`](/docs/react-types/ComponentProps)


### PR DESCRIPTION
This is a visual example of what I'm envisioning in https://github.com/typescript-cheatsheets/react/discussions/625. 

Having dedicated reference pages for each important React type with explanations and usage examples could probably be very useful.

I haven't been documenting types this way before so I'm not sure what a good way is. Exploring one way here. Happy to receive feedback!

What do you think about the overall idea here @eps1lon?