### PR TITLE
Update basic-type-examples.md

### DIFF
--- a/docs/basic/getting-started/basic-type-examples.md
+++ b/docs/basic/getting-started/basic-type-examples.md
@@ -65,7 +65,8 @@ Typing "any non-primitive value" is most likely not something that you should do
 An empty interface, `{}` and `Object` all represent "any non-nullish value"—not "an empty object" as you might think. [Using these types is a common source of misunderstanding and is not recommended](https://typescript-eslint.io/rules/no-empty-interface/).
 
 ```ts
-interface AnyNonNullishValue {} // equivalent to `type AnyNonNullishValue = {}` or `type AnyNonNullishValue = Object`
+interface AnyNonNullishValue {}
+// equivalent to `type AnyNonNullishValue = {}` or `type AnyNonNullishValue = Object`
 
 let value: AnyNonNullishValue;
 


### PR DESCRIPTION
If you hover over the code box you can't fully read the comment, So just added a line for clear reading.
![image](https://github.com/typescript-cheatsheets/react/assets/5627096/3121e453-ef16-4561-86fd-02aa5ffcbadf)
