### PR TITLE
Mark `React.FC` as "not needed" instead of "discouraged"

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,13 +194,19 @@ const App = ({ message }: AppProps): JSX.Element => <div>{message}</div>;
 
 // you can also inline the type declaration; eliminates naming the prop types, but looks repetitive
 const App = ({ message }: { message: string }) => <div>{message}</div>;
+
+// Alternatively, you can use `React.FunctionComponent` (or `React.FC`), if you prefer.
+// With latest React types and TypeScript 5.1. it's mostly a stylistic choice, otherwise discouraged.
+const App: React.FunctionComponent<{ message: string }> = ({ message }) => (
+  <div>{message}</div>
+);
 ```
 
 > Tip: You might use [Paul Shen's VS Code Extension](https://marketplace.visualstudio.com/items?itemName=paulshen.paul-typescript-toolkit) to automate the type destructure declaration (incl a [keyboard shortcut](https://twitter.com/_paulshen/status/1392915279466745857?s=20)).
 
 <details>
 
-<summary><b>Why is <code>React.FC</code> discouraged? What about <code>React.FunctionComponent</code>/<code>React.VoidFunctionComponent</code>?</b></summary>
+<summary><b>Why is <code>React.FC</code> not needed? What about <code>React.FunctionComponent</code>/<code>React.VoidFunctionComponent</code>?</b></summary>
 
 You may see this in many React+TypeScript codebases:
 
@@ -210,7 +216,7 @@ const App: React.FunctionComponent<{ message: string }> = ({ message }) => (
 );
 ```
 
-However, the general consensus today is that `React.FunctionComponent` (or the shorthand `React.FC`) is [discouraged](https://github.com/facebook/create-react-app/pull/8177). This is a nuanced opinion of course, but if you agree and want to remove `React.FC` from your codebase, you can use [this jscodeshift codemod](https://github.com/gndelia/codemod-replace-react-fc-typescript).
+However, the general consensus today is that `React.FunctionComponent` (or the shorthand `React.FC`) is not needed. If you're still using React 17 or TypeScript lower than 5.1, it is even [discouraged](https://github.com/facebook/create-react-app/pull/8177). This is a nuanced opinion of course, but if you agree and want to remove `React.FC` from your codebase, you can use [this jscodeshift codemod](https://github.com/gndelia/codemod-replace-react-fc-typescript).
 
 Some differences from the "normal function" version:
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ const App = ({ message }: AppProps): JSX.Element => <div>{message}</div>;
 const App = ({ message }: { message: string }) => <div>{message}</div>;
 
 // Alternatively, you can use `React.FunctionComponent` (or the shorthand `React.FC`), if you prefer.
-// With latest React types and TypeScript 5.1. it's mostly a stylistic choice, otherwise discouraged.
+// With latest React types (earliest is `@types/react@18.0.0`) and TypeScript 5.1. it's mostly a stylistic choice, otherwise discouraged.
 const App: React.FunctionComponent<{ message: string }> = ({ message }) => (
   <div>{message}</div>
 );

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ const App = ({ message }: AppProps): JSX.Element => <div>{message}</div>;
 // you can also inline the type declaration; eliminates naming the prop types, but looks repetitive
 const App = ({ message }: { message: string }) => <div>{message}</div>;
 
-// Alternatively, you can use `React.FunctionComponent` (or `React.FC`), if you prefer.
+// Alternatively, you can use `React.FunctionComponent` (or the shorthand `React.FC`), if you prefer.
 // With latest React types and TypeScript 5.1. it's mostly a stylistic choice, otherwise discouraged.
 const App: React.FunctionComponent<{ message: string }> = ({ message }) => (
   <div>{message}</div>

--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ const App = ({ message }: AppProps): JSX.Element => <div>{message}</div>;
 // you can also inline the type declaration; eliminates naming the prop types, but looks repetitive
 const App = ({ message }: { message: string }) => <div>{message}</div>;
 
-// Alternatively, you can use `React.FunctionComponent` (or the shorthand `React.FC`), if you prefer.
-// With latest React types (earliest is `@types/react@18.0.0`) and TypeScript 5.1. it's mostly a stylistic choice, otherwise discouraged.
+// Alternatively, you can use `React.FunctionComponent` (or `React.FC`), if you prefer.
+// With latest React types and TypeScript 5.1. it's mostly a stylistic choice, otherwise discouraged.
 const App: React.FunctionComponent<{ message: string }> = ({ message }) => (
   <div>{message}</div>
 );

--- a/docs/basic/getting-started/function-components.md
+++ b/docs/basic/getting-started/function-components.md
@@ -22,7 +22,9 @@ const App = ({ message }: { message: string }) => <div>{message}</div>;
 
 // Alternatively, you can use `React.FunctionComponent` (or `React.FC`), if you prefer.
 // With latest React types and TypeScript 5.1. it's mostly a stylistic choice, otherwise discouraged.
-const App: React.FunctionComponent<{ message: string }> = ({ message }) => <div>{message}</div>;
+const App: React.FunctionComponent<{ message: string }> = ({ message }) => (
+  <div>{message}</div>
+);
 ```
 
 > Tip: You might use [Paul Shen's VS Code Extension](https://marketplace.visualstudio.com/items?itemName=paulshen.paul-typescript-toolkit) to automate the type destructure declaration (incl a [keyboard shortcut](https://twitter.com/_paulshen/status/1392915279466745857?s=20)).

--- a/docs/basic/getting-started/function-components.md
+++ b/docs/basic/getting-started/function-components.md
@@ -19,13 +19,17 @@ const App = ({ message }: AppProps): JSX.Element => <div>{message}</div>;
 
 // you can also inline the type declaration; eliminates naming the prop types, but looks repetitive
 const App = ({ message }: { message: string }) => <div>{message}</div>;
+
+// Alternatively, you can use `React.FunctionComponent` (or `React.FC`), if you prefer.
+// With latest React types and TypeScript 5.1. it's mostly a stylistic choice, otherwise discouraged.
+const App: React.FunctionComponent<{ message: string }> = ({ message }) => <div>{message}</div>;
 ```
 
 > Tip: You might use [Paul Shen's VS Code Extension](https://marketplace.visualstudio.com/items?itemName=paulshen.paul-typescript-toolkit) to automate the type destructure declaration (incl a [keyboard shortcut](https://twitter.com/_paulshen/status/1392915279466745857?s=20)).
 
 <details>
 
-<summary><b>Why is <code>React.FC</code> discouraged? What about <code>React.FunctionComponent</code>/<code>React.VoidFunctionComponent</code>?</b></summary>
+<summary><b>Why is <code>React.FC</code> not needed? What about <code>React.FunctionComponent</code>/<code>React.VoidFunctionComponent</code>?</b></summary>
 
 You may see this in many React+TypeScript codebases:
 
@@ -35,7 +39,7 @@ const App: React.FunctionComponent<{ message: string }> = ({ message }) => (
 );
 ```
 
-However, the general consensus today is that `React.FunctionComponent` (or the shorthand `React.FC`) is [discouraged](https://github.com/facebook/create-react-app/pull/8177). This is a nuanced opinion of course, but if you agree and want to remove `React.FC` from your codebase, you can use [this jscodeshift codemod](https://github.com/gndelia/codemod-replace-react-fc-typescript).
+However, the general consensus today is that `React.FunctionComponent` (or the shorthand `React.FC`) is not needed. If you're still using React 17 or TypeScript lower than 5.1, it is even [discouraged](https://github.com/facebook/create-react-app/pull/8177). This is a nuanced opinion of course, but if you agree and want to remove `React.FC` from your codebase, you can use [this jscodeshift codemod](https://github.com/gndelia/codemod-replace-react-fc-typescript).
 
 Some differences from the "normal function" version:
 


### PR DESCRIPTION
Discouraged just triggers code-review discussions for what is today just a stylistic choice.  For React 17 or TypeScript 5.0 and lower it's still "discouraged".