### PR TITLE
Fix:#643

### DIFF
--- a/README.md
+++ b/README.md
@@ -1143,7 +1143,7 @@ Relevant for components that accept other React components as props.
 ```tsx
 export declare interface AppProps {
   children?: React.ReactNode; // best, accepts everything React can render
-  childrenElement: JSX.Element; // A single React element
+  childrenElement: React.ReactElement; // A single React element
   style?: React.CSSProperties; // to pass through style props
   onChange?: React.FormEventHandler<HTMLInputElement>; // form events! the generic parameter is the type of event.target
   //  more info: https://react-typescript-cheatsheet.netlify.app/docs/advanced/patterns_by_usecase/#wrappingmirroring

--- a/docs/basic/getting-started/basic-type-examples.md
+++ b/docs/basic/getting-started/basic-type-examples.md
@@ -88,7 +88,7 @@ Relevant for components that accept other React components as props.
 ```tsx
 export declare interface AppProps {
   children?: React.ReactNode; // best, accepts everything React can render
-  childrenElement: JSX.Element; // A single React element
+  childrenElement: React.ReactElement; // A single React element
   style?: React.CSSProperties; // to pass through style props
   onChange?: React.FormEventHandler<HTMLInputElement>; // form events! the generic parameter is the type of event.target
   //  more info: https://react-typescript-cheatsheet.netlify.app/docs/advanced/patterns_by_usecase/#wrappingmirroring

--- a/docs/basic/getting-started/function-components.md
+++ b/docs/basic/getting-started/function-components.md
@@ -15,7 +15,7 @@ type AppProps = {
 const App = ({ message }: AppProps) => <div>{message}</div>;
 
 // you can choose annotate the return type so an error is raised if you accidentally return some other type
-const App = ({ message }: AppProps): JSX.Element => <div>{message}</div>;
+const App = ({ message }: AppProps): React.ReactElement => <div>{message}</div>;
 
 // you can also inline the type declaration; eliminates naming the prop types, but looks repetitive
 const App = ({ message }: { message: string }) => <div>{message}</div>;


### PR DESCRIPTION
Thanks for contributing!

fix :#643
In " Typing Component Props " under " Useful React Prop Type Examples " , In " Functional Components " under 3rd example , example given for children Element as props ( JSX.Element ) is incorrect it produce errors in new versions , instead React.ReactElement is suggested method to use .

So changed it to React.ReactElement

![image](https://github.com/typescript-cheatsheets/react/assets/120321643/488e94e5-1ab8-49f2-913d-d15a85352194)

![image](https://github.com/typescript-cheatsheets/react/assets/120321643/696e7b00-4662-459c-86d6-a2b287ebb549)

