### PR TITLE
bugfix: Fixed Text overflowing in small devices

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -56,4 +56,14 @@ main details:hover {
   .homePageBtns {
     grid-template-columns: 1fr 1fr;
   }
+
+
+}
+
+
+@media (max-width:768px) {
+  .DocSearch-Button {
+    position: relative;
+    left: 5px;
+  }
 }


### PR DESCRIPTION
Thanks for contributing!

 Bugfix - The logo text is overflowing in small devices it should be truncated like mobile navigation.
Issue no - 646