### PR TITLE
fix : #646 [Bug] The logo text is overflowing in small devices it should be trun…

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -57,3 +57,8 @@ main details:hover {
     grid-template-columns: 1fr 1fr;
   }
 }
+@media (max-width: 320px) {
+  .navbar__title {
+    width: 170px;
+  }
+}


### PR DESCRIPTION
- issue : https://github.com/typescript-cheatsheets/react/issues/646
- changes : added styles for navbar__title for small width
![Screenshot 2023-10-01 105028](https://github.com/typescript-cheatsheets/react/assets/110347815/5b3b7997-f874-4f69-a416-33a7e14b8ff3)
