### PR TITLE
Fixed the navbar styling to make it wrap on small screen sizes

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -52,8 +52,15 @@ main details:hover {
   display: grid;
   gap: 20px;
 }
+
 @media (min-width: 480px) {
   .homePageBtns {
     grid-template-columns: 1fr 1fr;
   }
+}
+
+.navbar__title {
+  white-space: normal;
+  word-break: normal;
+  overflow-wrap: anywhere;
 }


### PR DESCRIPTION
This PR fixes the issue of the navbar title overflowing on small devices by making the title wrap on a new line.

Fixes: #646
![image](https://github.com/typescript-cheatsheets/react/assets/99811918/8ab5f37b-0236-480e-8bee-bbe7a29a7cae)
