### PR TITLE
Fix: typo in context.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1532,7 +1532,7 @@ const MyComponent = () => {
 };
 ```
 
-However, it would be preferrable to not have to check for `null`, since we know that the context won't be `null`. One way to do that is to provide a custom hook to use the context, where an error is thrown if the context is not provided:
+However, it would be preferable to not have to check for `null`, since we know that the context won't be `null`. One way to do that is to provide a custom hook to use the context, where an error is thrown if the context is not provided:
 
 ```tsx
 import { createContext } from "react";

--- a/docs/basic/getting-started/context.md
+++ b/docs/basic/getting-started/context.md
@@ -83,7 +83,7 @@ const MyComponent = () => {
 };
 ```
 
-However, it would be preferrable to not have to check for `null`, since we know that the context won't be `null`. One way to do that is to provide a custom hook to use the context, where an error is thrown if the context is not provided:
+However, it would be preferable to not have to check for `null`, since we know that the context won't be `null`. One way to do that is to provide a custom hook to use the context, where an error is thrown if the context is not provided:
 
 ```tsx
 import { createContext } from "react";


### PR DESCRIPTION
Thanks for contributing!

- **If you are making a significant PR**, please make sure there is an open issue first
- **If you're just fixing typos or adding small notes**, a brief explanation of why you'd like to add it would be nice :)

**If you are contributing to README.md, DON'T**. README.md is auto-generated. Please just make edits to the source inside of `/docs/basic`. _Sorry, we get that it is a slight pain._
Fixed a minor typo in docs/basic/getting-started/context.md file:
preferrable -> preferable
