### PR TITLE
removed Matterhorn blog link since it is not working

### DIFF
--- a/docs/basic/linting.md
+++ b/docs/basic/linting.md
@@ -98,7 +98,7 @@ More `.eslintrc.json` options to consider with more options you may want for **a
 }
 ```
 
-You can read a [fuller TypeScript + ESLint setup guide here](https://blog.matterhorn.dev/posts/learn-typescript-linting-part-1/) from Matterhorn, in particular check https://github.com/MatterhornDev/learn-typescript-linting.
+You can check https://github.com/MatterhornDev/learn-typescript-linting from Matterhorn.
 
 Another great resource is ["Using ESLint and Prettier in a TypeScript Project"](https://dev.to/robertcoopercode/using-eslint-and-prettier-in-a-typescript-project-53jb) by @robertcoopercode.
 


### PR DESCRIPTION
I removed the Matterhorn blog post in the linting page since it's not working