### PR TITLE
Fix "Redeclare" typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1696,7 +1696,7 @@ export function ClickableList<T>(props: ClickableListProps<T>) {
 ##### Option 2 - Redeclare forwardRef
 
 ```ts
-// Redecalare forwardRef
+// Redeclare forwardRef
 declare module "react" {
   function forwardRef<T, P = {}>(
     render: (props: P, ref: React.Ref<T>) => React.ReactElement | null

--- a/docs/basic/getting-started/forward-create-ref.md
+++ b/docs/basic/getting-started/forward-create-ref.md
@@ -95,7 +95,7 @@ export function ClickableList<T>(props: ClickableListProps<T>) {
 ### Option 2 - Redeclare forwardRef
 
 ```ts
-// Redecalare forwardRef
+// Redeclare forwardRef
 declare module "react" {
   function forwardRef<T, P = {}>(
     render: (props: P, ref: React.Ref<T>) => React.ReactElement | null


### PR DESCRIPTION
Noticed this minor typo. Wasn't sure whether I should _only_ update `docs/basic/getting-started/forward-create-ref.md` or generate the new `README.md` as well. It's included for now, let me know if this is okay!