### PR TITLE
Add React.FC example with predefined type

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ const App = ({ message }: { message: string }) => <div>{message}</div>;
 const App: React.FunctionComponent<{ message: string }> = ({ message }) => (
   <div>{message}</div>
 );
+// or
+const App: React.FC<AppProps> = ({ message }) => <div>{message}</div>;
 ```
 
 > Tip: You might use [Paul Shen's VS Code Extension](https://marketplace.visualstudio.com/items?itemName=paulshen.paul-typescript-toolkit) to automate the type destructure declaration (incl a [keyboard shortcut](https://twitter.com/_paulshen/status/1392915279466745857?s=20)).

--- a/docs/basic/getting-started/function-components.md
+++ b/docs/basic/getting-started/function-components.md
@@ -25,6 +25,10 @@ const App = ({ message }: { message: string }) => <div>{message}</div>;
 const App: React.FunctionComponent<{ message: string }> = ({ message }) => (
   <div>{message}</div>
 );
+// or
+const App: React.FC<AppProps> = ({ message }) => (
+  <div>{message}</div>
+);
 ```
 
 > Tip: You might use [Paul Shen's VS Code Extension](https://marketplace.visualstudio.com/items?itemName=paulshen.paul-typescript-toolkit) to automate the type destructure declaration (incl a [keyboard shortcut](https://twitter.com/_paulshen/status/1392915279466745857?s=20)).

--- a/docs/basic/getting-started/function-components.md
+++ b/docs/basic/getting-started/function-components.md
@@ -26,9 +26,7 @@ const App: React.FunctionComponent<{ message: string }> = ({ message }) => (
   <div>{message}</div>
 );
 // or
-const App: React.FC<AppProps> = ({ message }) => (
-  <div>{message}</div>
-);
+const App: React.FC<AppProps> = ({ message }) => <div>{message}</div>;
 ```
 
 > Tip: You might use [Paul Shen's VS Code Extension](https://marketplace.visualstudio.com/items?itemName=paulshen.paul-typescript-toolkit) to automate the type destructure declaration (incl a [keyboard shortcut](https://twitter.com/_paulshen/status/1392915279466745857?s=20)).


### PR DESCRIPTION
To show a fair comparison between the different approaches on how to type a react component, the `React.FC<AppProps>` approach should also be listed. It may be technically similar but has the best readability from my experience.
