### PR TITLE
Added React and TypeScript starter kit using vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ React has documentation for [how to start a new React project](https://react.dev
 - [Remix](https://remix.run/docs/tutorials/blog): `npx create-remix@latest`
 - [Gatsby](https://www.gatsbyjs.com/docs/how-to/custom-configuration/typescript/): `npm init gatsby --ts`
 - [Expo](https://docs.expo.dev/guides/typescript/): `npx create-expo-app -t with-typescript`
+- [Vite](https://vitejs.dev/guide/): `npm create vite@latest my-vite-app -- --template react-ts`
 
 #### Try React and TypeScript online
 

--- a/docs/basic/setup.md
+++ b/docs/basic/setup.md
@@ -20,6 +20,7 @@ React has documentation for [how to start a new React project](https://react.dev
 - [Remix](https://remix.run/docs/tutorials/blog): `npx create-remix@latest`
 - [Gatsby](https://www.gatsbyjs.com/docs/how-to/custom-configuration/typescript/): `npm init gatsby --ts`
 - [Expo](https://docs.expo.dev/guides/typescript/): `npx create-expo-app -t with-typescript`
+- [Vite](https://vitejs.dev/guide/): `npm create vite@latest my-vite-app -- --template react-ts`
 
 ## Try React and TypeScript online
 


### PR DESCRIPTION
I would like to add the Vite starter kit command for setting up a React and TypeScript project, as it's a popular choice among developers looking for a fast and lightweight setup. The command to create a new project with Vite is:
npm create vite@latest my-vite-app -- --template react-ts
This addition complements the existing starter kits for frameworks like Next.js, Remix, Gatsby, and Expo, providing a comprehensive overview for users.