### PR TITLE
Fix: Update GitHub Star Image URL to Resolve Broken Link (BROKEN IMAGE #737)

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -150,7 +150,7 @@ module.exports = {
             },
             {
               html: `<a class="footer__link-item" href="https://github.com/typescript-cheatsheets/react">
-                <img src="https://camo.githubusercontent.com/f00e074779455222f68fde1096fbbd91bae555c2/68747470733a2f2f696d672e736869656c64732e696f2f6769746875622f73746172732f747970657363726970742d63686561747368656574732f72656163742d747970657363726970742d636865617473686565742e7376673f7374796c653d736f6369616c266c6162656c3d53746172266d61784167653d32353932303030" alt="GitHub stars" data-canonical-src="https://img.shields.io/github/stars/typescript-cheatsheets/react-typescript-cheatsheet.svg?style=social&amp;label=Star&amp;maxAge=2592000" style="max-width:100%;">
+                <img src="https://img.shields.io/github/stars/typescript-cheatsheets/react-typescript-cheatsheet.svg?style=social&amp;label=Star&amp;maxAge=2592000" alt="GitHub stars" data-canonical-src="https://img.shields.io/github/stars/typescript-cheatsheets/react-typescript-cheatsheet.svg?style=social&amp;label=Star&amp;maxAge=2592000" style="max-width:100%;">
                 </a>`,
             },
             {


### PR DESCRIPTION
Here's the PR description in bullet points with a comparison of the footer states:

- Fixed the broken GitHub star image link in the docusaurus.config.js file.

- Updated the faulty link and replaced it with the correct URL for the GitHub star badge.

- Earlier, the footer appeared like this:

![Screenshot 2024-10-02 004757](https://github.com/user-attachments/assets/c4036e78-d600-401f-8b2e-877b4de16810)

- Now, after the fix, the footer looks like this:

![Screenshot 2024-10-02 004909](https://github.com/user-attachments/assets/aea1ecac-fb58-4bb5-9fdc-481817c666aa)

- The updated footer now displays the GitHub star image properly, resolving the issue.