### PR TITLE
docs: fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Cheatsheets for experienced React developers getting started with TypeScript
 - [The Migrating Cheatsheet](https://react-typescript-cheatsheet.netlify.app/docs/migration) helps collate advice for incrementally migrating large codebases from JS or Flow, **from people who have done it**.
   - We do not try to convince people to switch, only to help people who have already decided.
   - ⚠️This is a new cheatsheet, all assistance is welcome.
-- [The HOC Cheatsheet](https://react-typescript-cheatsheet.netlify.app/docs/hoc)) specifically teaches people to write HOCs with examples.
+- [The HOC Cheatsheet](https://react-typescript-cheatsheet.netlify.app/docs/hoc) specifically teaches people to write HOCs with examples.
   - Familiarity with [Generics](https://www.typescriptlang.org/docs/handbook/2/generics.html) is necessary.
   - ⚠️This is the newest cheatsheet, all assistance is welcome.
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ React has documentation for [how to start a new React project](https://react.dev
 - [Remix](https://remix.run/docs/tutorials/blog): `npx create-remix@latest`
 - [Gatsby](https://www.gatsbyjs.com/docs/how-to/custom-configuration/typescript/): `npm init gatsby --ts`
 - [Expo](https://docs.expo.dev/guides/typescript/): `npx create-expo-app -t with-typescript`
+- [Vite](https://vite.dev/guide/): `npm create vite@latest my-react-app -- --template react-ts`
 
 #### Try React and TypeScript online
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ React has documentation for [how to start a new React project](https://react.dev
 - [Remix](https://remix.run/docs/tutorials/blog): `npx create-remix@latest`
 - [Gatsby](https://www.gatsbyjs.com/docs/how-to/custom-configuration/typescript/): `npm init gatsby --ts`
 - [Expo](https://docs.expo.dev/guides/typescript/): `npx create-expo-app -t with-typescript`
-- [Vite](https://vite.dev/guide/): `npm create vite@latest my-react-app -- --template react-ts`
 
 #### Try React and TypeScript online
 

--- a/docs/basic/setup.md
+++ b/docs/basic/setup.md
@@ -20,7 +20,6 @@ React has documentation for [how to start a new React project](https://react.dev
 - [Remix](https://remix.run/docs/tutorials/blog): `npx create-remix@latest`
 - [Gatsby](https://www.gatsbyjs.com/docs/how-to/custom-configuration/typescript/): `npm init gatsby --ts`
 - [Expo](https://docs.expo.dev/guides/typescript/): `npx create-expo-app -t with-typescript`
-- [Vite](https://vite.dev/guide/): `npm create vite@latest my-react-app -- --template react-ts`
 
 ## Try React and TypeScript online
 

--- a/docs/basic/setup.md
+++ b/docs/basic/setup.md
@@ -20,6 +20,7 @@ React has documentation for [how to start a new React project](https://react.dev
 - [Remix](https://remix.run/docs/tutorials/blog): `npx create-remix@latest`
 - [Gatsby](https://www.gatsbyjs.com/docs/how-to/custom-configuration/typescript/): `npm init gatsby --ts`
 - [Expo](https://docs.expo.dev/guides/typescript/): `npx create-expo-app -t with-typescript`
+- [Vite](https://vite.dev/guide/): `npm create vite@latest my-react-app -- --template react-ts`
 
 ## Try React and TypeScript online
 


### PR DESCRIPTION
- Add Vite to the setup (as the Vite react starter template is also very popular)
- Fix a bracket typo on the HOC Cheatsheet part at the "All React + TypeScript Cheatsheets" section
