### PR TITLE
Enhance `useReducer` example and add section on explicit typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ type ACTIONTYPE =
   | { type: "increment"; payload: number }
   | { type: "decrement"; payload: string };
 
-function reducer(state: typeof initialState, action: ACTIONTYPE) {
+function reducer(state: typeof initialState, action: ACTIONTYPE): typeof initialState {
   switch (action.type) {
     case "increment":
       return { count: state.count + action.payload };

--- a/README.md
+++ b/README.md
@@ -429,6 +429,18 @@ export function reducer: Reducer<AppState, Action>() {}
 
 </details>
 
+<details>
+
+<summary><b>Providing explicit types for <code>useReducer</code></b></summary>
+
+In most cases, type inference for useReducer should work reliably. When inference fails, the state and action types can be explicitly provided using the following syntax, where the action type is wrapped in a single-element tuple.
+
+```tsx
+const [state, dispatch] = useReducer<typeof initialState, [ACTIONTYPE]>(reducer, initialState);
+```
+
+</details>
+
 #### useEffect / useLayoutEffect
 
 Both of `useEffect` and `useLayoutEffect` are used for performing <b>side effects</b> and return an optional cleanup function which means if they don't deal with returning values, no types are necessary. When using `useEffect`, take care not to return anything other than a function or `undefined`, otherwise both TypeScript and React will yell at you. This can be subtle when using arrow functions:

--- a/README.md
+++ b/README.md
@@ -384,7 +384,10 @@ type ACTIONTYPE =
   | { type: "increment"; payload: number }
   | { type: "decrement"; payload: string };
 
-function reducer(state: typeof initialState, action: ACTIONTYPE): typeof initialState {
+function reducer(
+  state: typeof initialState,
+  action: ACTIONTYPE
+): typeof initialState {
   switch (action.type) {
     case "increment":
       return { count: state.count + action.payload };
@@ -436,7 +439,10 @@ export function reducer: Reducer<AppState, Action>() {}
 In most cases, type inference for useReducer should work reliably. When inference fails, the state and action types can be explicitly provided using the following syntax, where the action type is wrapped in a single-element tuple.
 
 ```tsx
-const [state, dispatch] = useReducer<typeof initialState, [ACTIONTYPE]>(reducer, initialState);
+const [state, dispatch] = useReducer<typeof initialState, [ACTIONTYPE]>(
+  reducer,
+  initialState
+);
 ```
 
 </details>

--- a/docs/basic/getting-started/hooks.md
+++ b/docs/basic/getting-started/hooks.md
@@ -93,7 +93,10 @@ type ACTIONTYPE =
   | { type: "increment"; payload: number }
   | { type: "decrement"; payload: string };
 
-function reducer(state: typeof initialState, action: ACTIONTYPE): typeof initialState {
+function reducer(
+  state: typeof initialState,
+  action: ACTIONTYPE
+): typeof initialState {
   switch (action.type) {
     case "increment":
       return { count: state.count + action.payload };
@@ -145,7 +148,10 @@ export function reducer: Reducer<AppState, Action>() {}
 In most cases, type inference for useReducer should work reliably. When inference fails, the state and action types can be explicitly provided using the following syntax, where the action type is wrapped in a single-element tuple.
 
 ```tsx
-const [state, dispatch] = useReducer<typeof initialState, [ACTIONTYPE]>(reducer, initialState);
+const [state, dispatch] = useReducer<typeof initialState, [ACTIONTYPE]>(
+  reducer,
+  initialState
+);
 ```
 
 </details>

--- a/docs/basic/getting-started/hooks.md
+++ b/docs/basic/getting-started/hooks.md
@@ -93,7 +93,7 @@ type ACTIONTYPE =
   | { type: "increment"; payload: number }
   | { type: "decrement"; payload: string };
 
-function reducer(state: typeof initialState, action: ACTIONTYPE) {
+function reducer(state: typeof initialState, action: ACTIONTYPE): typeof initialState {
   switch (action.type) {
     case "increment":
       return { count: state.count + action.payload };

--- a/docs/basic/getting-started/hooks.md
+++ b/docs/basic/getting-started/hooks.md
@@ -138,6 +138,18 @@ export function reducer: Reducer<AppState, Action>() {}
 
 </details>
 
+<details>
+
+<summary><b>Providing explicit types for <code>useReducer</code></b></summary>
+
+In most cases, type inference for useReducer should work reliably. When inference fails, the state and action types can be explicitly provided using the following syntax, where the action type is wrapped in a single-element tuple.
+
+```tsx
+const [state, dispatch] = useReducer<typeof initialState, [ACTIONTYPE]>(reducer, initialState);
+```
+
+</details>
+
 ## useEffect / useLayoutEffect
 
 Both of `useEffect` and `useLayoutEffect` are used for performing <b>side effects</b> and return an optional cleanup function which means if they don't deal with returning values, no types are necessary. When using `useEffect`, take care not to return anything other than a function or `undefined`, otherwise both TypeScript and React will yell at you. This can be subtle when using arrow functions:


### PR DESCRIPTION
Hello,
I noticed that in the `useReducer` section, the introductory text strongly recommends adding a return type for the reducer, but the code example does not include one. Additionally, I added a section on explicit typing for `useReducer` for cases where TypeScript can't infer the correct types from the reducer, as mentioned in the [React 19 upgrade guide](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#better-usereducer-typings)

Cheers